### PR TITLE
Added check for array with objects

### DIFF
--- a/app/jobs/papyrus/update_print_node_information_job.rb
+++ b/app/jobs/papyrus/update_print_node_information_job.rb
@@ -15,7 +15,7 @@ module Papyrus
 
         computer_client_ids << c.id
 
-        Papyrus.print_client.printers(c.id, '').each do |p|
+        Papyrus.print_client.printers(c.id, '').flatten.each do |p|
           printer = Papyrus::Printer.find_or_initialize_by(client_id: p.id)
           printer.name = p.name
           printer.description = p.description


### PR DESCRIPTION
Fixed error - 
NoMethodError: undefined method `id' for an instance of Array

papyrus	app/jobs/papyrus/update_print_node_information_job.rb:19
papyrus	app/jobs/papyrus/update_print_node_information_job.rb:18
papyrus	app/jobs/papyrus/update_print_node_information_job.rb:18