### PR TITLE
Exception Error - Modified wrong foreign key

### DIFF
--- a/app/models/papyrus/computer.rb
+++ b/app/models/papyrus/computer.rb
@@ -1,6 +1,6 @@
 module Papyrus
   class Computer < ApplicationRecord
     has_many :printers, class_name: 'Printer', foreign_key: 'computer_id', dependent: :destroy
-    has_many :preferred_printers, class_name: 'PreferredPrinter', foreign_key: 'printer_id', dependent: :destroy
+    has_many :preferred_printers, class_name: 'PreferredPrinter', foreign_key: 'computer_id', dependent: :destroy
   end
 end

--- a/app/models/papyrus/computer.rb
+++ b/app/models/papyrus/computer.rb
@@ -1,6 +1,6 @@
 module Papyrus
   class Computer < ApplicationRecord
-    has_many :printers, class_name: 'Printer', foreign_key: 'printer_id', dependent: :destroy
+    has_many :printers, class_name: 'Printer', foreign_key: 'computer_id', dependent: :destroy
     has_many :preferred_printers, class_name: 'PreferredPrinter', foreign_key: 'printer_id', dependent: :destroy
   end
 end


### PR DESCRIPTION
https://github.com/boxture/oms/issues/3831

Fixed exception - 
https://oms.staging.boxture.com/exceptions/exceptions/f63f84f6-d8cf-4157-928f-f3f3d8f49bcb
PG::UndefinedColumn: ERROR: column papyrus_printers.printer_id does not exist LINE 1: ...papyrus_printers".* FROM "papyrus_printers" WHERE "papyrus_p... ^


-  Modified foreign key from printer_id to computer_id as per DB structure